### PR TITLE
修复一行最多显示一条弹幕的问题

### DIFF
--- a/HJDanmaku/Model/DanmakuBaseModel.m
+++ b/HJDanmaku/Model/DanmakuBaseModel.m
@@ -46,10 +46,10 @@
 
 - (void)layoutWithScreenWidth:(float)width;
 {
-    self.px = [self pxWithScreenWidth:width RemainTime:self.remainTime];
+    self.px = [self pxWithScreenWidth:width remainTime:self.remainTime];
 }
 
-- (float)pxWithScreenWidth:(float)width RemainTime:(float)remainTime
+- (float)pxWithScreenWidth:(float)width remainTime:(float)remainTime
 {
     return -self.size.width+(width+self.size.width)/self.duration*remainTime;
 }


### PR DESCRIPTION
因为方法名大小写错误，导致未能覆盖父类方法，进而使得在计算碰撞宽度时使用了父类的-self.size.width，从而出现一行最多仅显示一条弹幕的问题
